### PR TITLE
jpa-core 및 exception-handler-core 모듈 추가

### DIFF
--- a/core/core.settings.gradle.kts
+++ b/core/core.settings.gradle.kts
@@ -1,3 +1,12 @@
+val core = rootDir.resolve("core")
+    .walkTopDown()
+    .maxDepth(3)
+    .filter(File::isDirectory)
+    .associateBy(File::getName)
+
+
 include(
-    "core"
+    ":jpa-core",
 )
+
+project(":jpa-core").projectDir = core["jpa-core"]!!

--- a/core/core.settings.gradle.kts
+++ b/core/core.settings.gradle.kts
@@ -7,6 +7,8 @@ val core = rootDir.resolve("core")
 
 include(
     ":jpa-core",
+    ":exception-handler-core"
 )
 
 project(":jpa-core").projectDir = core["jpa-core"]!!
+project(":exception-handler-core").projectDir = core["exception-handler-core"]!!

--- a/core/exception-handler-core/build.gradle.kts
+++ b/core/exception-handler-core/build.gradle.kts
@@ -1,0 +1,8 @@
+dependencies {
+    implementation(project(":common"))
+
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
+}

--- a/core/exception-handler-core/src/main/java/me/nettee/handler/GlobalExceptionHandler.java
+++ b/core/exception-handler-core/src/main/java/me/nettee/handler/GlobalExceptionHandler.java
@@ -1,0 +1,30 @@
+package me.nettee.handler;
+
+import me.nettee.CustomException;
+import me.nettee.ErrorCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import me.nettee.response.ApiErrorResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CustomException.class) // 모든 커스텀 익셉션
+    public ResponseEntity<?> handleCustomException(CustomException exception) {
+        
+        ErrorCode errorCode = exception.getErrorCode();
+        
+        exception.execute();
+ 
+        var responseBody = ApiErrorResponse.builder()
+                .status(errorCode.httpStatus().value())
+                .code(errorCode.name())
+                .message(exception.getMessage()) // same to errorCode.message
+                .payload(exception.getPayload())
+                .build();
+        
+        return ResponseEntity
+                .status(errorCode.httpStatus())
+                .body(responseBody);
+    }
+}

--- a/core/exception-handler-core/src/main/java/me/nettee/response/ApiErrorResponse.java
+++ b/core/exception-handler-core/src/main/java/me/nettee/response/ApiErrorResponse.java
@@ -1,0 +1,19 @@
+package me.nettee.response;
+
+import lombok.Builder;
+
+import java.util.Map;
+
+@Builder
+public record ApiErrorResponse(
+        int status,
+        String code,
+        String message,
+        Map<String, Object> payload
+) {
+    public ApiErrorResponse {
+        if (payload != null && payload.isEmpty()) {
+            payload = null;
+        }
+    }
+}

--- a/core/jpa-core/build.gradle.kts
+++ b/core/jpa-core/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    `java-library`
+}
+
+version = "0.0.1-SNAPSHOT"
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+
+    // lombok
+    compileOnly("org.projectlombok:lombok")
+    annotationProcessor("org.projectlombok:lombok")
+    testCompileOnly("org.projectlombok:lombok")
+    testAnnotationProcessor("org.projectlombok:lombok")
+
+    // querydsl
+    implementation("com.querydsl:querydsl-jpa:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties["querydsl.version"]}:jakarta")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+}

--- a/core/jpa-core/src/main/java/me/nettee/config/JpaConfig.java
+++ b/core/jpa-core/src/main/java/me/nettee/config/JpaConfig.java
@@ -1,0 +1,14 @@
+package me.nettee.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EnableJpaAuditing
+@EntityScan(basePackages = "me.nettee") // 엔티티 패키지 지정
+@EnableJpaRepositories(basePackages = "me.nettee") // 리포지토리 패키지 지정
+public class JpaConfig {
+
+}

--- a/core/jpa-core/src/main/java/me/nettee/support/BaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/me/nettee/support/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package me.nettee.support;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity implements Serializable {
+    @CreatedDate
+    private Instant createdAt;
+    
+    @LastModifiedDate
+    private Instant updatedAt;
+}

--- a/core/jpa-core/src/main/java/me/nettee/support/LongBaseEntity.java
+++ b/core/jpa-core/src/main/java/me/nettee/support/LongBaseEntity.java
@@ -1,0 +1,17 @@
+package me.nettee.support;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+@MappedSuperclass
+public abstract class LongBaseEntity implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/core/jpa-core/src/main/java/me/nettee/support/LongBaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/me/nettee/support/LongBaseTimeEntity.java
@@ -1,0 +1,21 @@
+package me.nettee.support;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class LongBaseTimeEntity extends LongBaseEntity {
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+}

--- a/core/jpa-core/src/main/java/me/nettee/support/UuidBaseEntity.java
+++ b/core/jpa-core/src/main/java/me/nettee/support/UuidBaseEntity.java
@@ -1,0 +1,18 @@
+package me.nettee.support;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Getter
+@MappedSuperclass
+public abstract class UuidBaseEntity implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+}

--- a/core/jpa-core/src/main/java/me/nettee/support/UuidBaseTimeEntity.java
+++ b/core/jpa-core/src/main/java/me/nettee/support/UuidBaseTimeEntity.java
@@ -1,0 +1,21 @@
+package me.nettee.support;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class UuidBaseTimeEntity extends UuidBaseEntity {
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+}


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #5 

## Description

- 공통 JPAjpa 설정을 위한 jpa-core 모듈 추가
- 예외 처리 공통화를 위한 exception-handler-core 모듈을 추가함.


- jpa-core
  - JpaConfig
  - LongBaseEntity
  - BaseTimeEntity / LongBaseTimeEntity
  - UuidBaseEntity / UuidBaseTimeEntity

- exception-handler-core
  - GlobalExceptionHandler
  - ApiErrorResponse

