### PR TITLE
루트 `build.gradle.kts`에 자바 버전(21) 추가 외 1 건

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,10 @@ subprojects {
     }
 
     dependencies {
+        if(project.name != "common") {
+            api(project(":common"))
+        }
+
         compileOnly("org.projectlombok:lombok")
         annotationProcessor("org.projectlombok:lombok")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,10 @@ plugins {
 allprojects {
     group = "me.nettee"
     version = "1.0-SNAPSHOT"
+
+    repositories {
+        mavenCentral()
+    }
 }
 
 subprojects {
@@ -24,13 +28,15 @@ subprojects {
         plugin("org.jetbrains.kotlin.plugin.spring")
     }
 
+    java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(21)
+        }
+    }
+
     dependencies {
         compileOnly("org.projectlombok:lombok")
         annotationProcessor("org.projectlombok:lombok")
-    }
-
-    repositories {
-        mavenCentral()
     }
 
     tasks.withType<BootJar>{


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #24
- Resolves #26 

## Description

- 루트 프로젝트에 기본 자바 버전(21)을 명시합니다.
- 루트 프로젝트에서  `common` 외 다른 모든 모듈에 `common` 모듈 의존성을 추가합니다.
