### PR TITLE
feat(board): fix visibility of entity fields to `public`

### DIFF
--- a/services/board/driven/rdb/src/main/java/nettee/board/entity/BoardEntity.java
+++ b/services/board/driven/rdb/src/main/java/nettee/board/entity/BoardEntity.java
@@ -2,7 +2,6 @@ package nettee.board.entity;
 
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,41 +16,16 @@ import org.hibernate.annotations.DynamicUpdate;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity(name = "board")
 public class BoardEntity extends LongBaseTimeEntity {
-    private String title;
-    private String content;
+    public String title;
+    public String content;
 
     @Convert(converter = BoardEntityStatusConverter.class)
-    private BoardEntityStatus status;
+    public BoardEntityStatus status;
 
     @Builder
     public BoardEntity(String title, String content, BoardEntityStatus status) {
         this.title = title;
         this.content = content;
-        this.status = status;
-    }
-
-    @Builder(
-            builderClassName = "UpdateBoardBuilder",
-            builderMethodName = "prepareUpdate",
-            buildMethodName = "update"
-    )
-    public void updateBoard(String title, String content, BoardEntityStatus status) {
-        Objects.requireNonNull(title, "title cannot be null");
-        Objects.requireNonNull(content, "content cannot be null");
-        Objects.requireNonNull(status, "status cannot be null");
-
-        this.title = title;
-        this.content = content;
-        this.status = status;
-    }
-    
-    @Builder(
-            builderClassName = "UpdateStatusBoardBuilder",
-            builderMethodName = "prepareUpdateStatus",
-            buildMethodName = "updateStatus"
-    )
-    public void updateStatus(BoardEntityStatus status) {
-        Objects.requireNonNull(status, "status cannot be null");
         this.status = status;
     }
 }


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #42 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- JPA Entity 필드의 액세스 범위를 `public`으로 수정합니다.
- 수정을 위한 메서드는 우선 모두 삭제합니다.

## How Has This Been Tested?

- 초기 세팅 시 테스트 코드를 생략하고 있습니다.

## Additional Notes

다음을 보장하므로 `public` 필드로 개방하여 편의성을 증가시킵니다.

- 공개 범위를 열어 두어도 모듈화로 인해 외부에 직접 사용되지 않는 엔티티입니다.
- 불필요한 업데이트 전략을 생략하고, 편하게 필드 대입을 허용합니다.
- JPA Entity가 사용되는 영역이 매우 제한적이므로 실수가 거의 발생하지 않고, 검토가 매우 쉽습니다.