### PR TITLE
Common > Status Code: 비트에 의미를 담은 상태 코드 공급기 구현

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,5 +1,7 @@
 // FIXME remove this after root build.gradle.kts supplies below dependencies.
 dependencies {
+    testImplementation("org.springframework:spring-web:6.2.3")
+
     testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
     testImplementation("io.mockk:mockk:1.13.12")
     testImplementation(kotlin("script-runtime"))

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,0 +1,16 @@
+// FIXME remove this after root build.gradle.kts supplies below dependencies.
+dependencies {
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation(kotlin("script-runtime"))
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+}
+
+// FIXME remove this after root build.gradle.kts supplies below task.
+kotlin {
+    sourceSets {
+        test {
+            kotlin.srcDirs(listOf("src/test/kotlin"))
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/marker/TypeSafeMarker.java
+++ b/common/src/main/java/nettee/common/marker/TypeSafeMarker.java
@@ -1,0 +1,6 @@
+package nettee.common.marker;
+
+public sealed interface TypeSafeMarker permits TypeSafeMarker.Present, TypeSafeMarker.Missing {
+    final class Present implements TypeSafeMarker { private Present() {} }
+    final class Missing implements TypeSafeMarker { private Missing() {} }
+}

--- a/common/src/main/java/nettee/common/status/CustomStatusParameters.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParameters.java
@@ -3,7 +3,6 @@ package nettee.common.status;
 import nettee.common.marker.TypeSafeMarker;
 import nettee.common.marker.TypeSafeMarker.Missing;
 import nettee.common.marker.TypeSafeMarker.Present;
-import nettee.common.status.CustomStatusParametersSupplier.LongGeneralPurposeFeaturesValue;
 
 import java.util.Collection;
 
@@ -22,10 +21,7 @@ public class CustomStatusParameters<
         C extends TypeSafeMarker,
         I extends TypeSafeMarker
 > {
-    private final long sysInfoMax;
-    private final long categoryMax;
-    private final long instanceDetailMax;
-    private final LongGeneralPurposeFeaturesValue featuresBits;
+    private final CustomStatusParametersSupplier supplier;
 
     private long generalPurposeBits;
     private long systemInfoBits;
@@ -34,10 +30,7 @@ public class CustomStatusParameters<
     private long instanceBits;
 
     CustomStatusParameters(CustomStatusParametersSupplier supplier) {
-        this.sysInfoMax = (1L << supplier.systemInfoBitSize()) - 1;
-        this.categoryMax = (1L << supplier.categoryBitSize()) - 1;
-        this.instanceDetailMax = (1L << supplier.instanceDetailBitSize()) - 1;
-        this.featuresBits = supplier.features();
+        this.supplier = supplier;
     }
 
     public static CustomStatusParameters<Missing, Missing> generateWith(CustomStatusParametersSupplier supplier) {
@@ -48,16 +41,17 @@ public class CustomStatusParameters<
             Collection<String> extendedFeatures,
             LongGeneralPurposeFeatures... features
     ) {
-        generalPurposeBits = featuresBits.getValueOf(extendedFeatures, features);
+        generalPurposeBits = supplier.features().getValueOf(extendedFeatures, features);
         return this;
     }
 
     public CustomStatusParameters<C, I> generalPurposeFeatures(LongGeneralPurposeFeatures... features) {
-        generalPurposeBits = featuresBits.getValueOf(features);
+        generalPurposeBits = supplier.features().getValueOf(features);
         return this;
     }
 
     public CustomStatusParameters<C, I> systemInfoBits(long systemInfoBits) {
+        long sysInfoMax = (1L << supplier.systemInfoBitSize()) - 1;
         if (systemInfoBits > sysInfoMax) {
             throw SYS_INFO_OVERFLOW.exception();
         }
@@ -66,6 +60,7 @@ public class CustomStatusParameters<
     }
 
     public CustomStatusParameters<Present, I> categoryBits(long categoryBits) {
+        long categoryMax = (1L << supplier.categoryBitSize()) - 1;
         if (categoryBits > categoryMax) {
             throw CATEGORY_BITS_OVERFLOW.exception();
         }
@@ -76,6 +71,7 @@ public class CustomStatusParameters<
     }
 
     public CustomStatusParameters<C, Present> instanceBits(long instanceBits) {
+        long instanceDetailMax = (1L << supplier.instanceDetailBitSize()) - 1;
         if (instanceBits > instanceDetailMax) {
             throw INSTANCE_DETAIL_BITS_OVERFLOW.exception();
         }

--- a/common/src/main/java/nettee/common/status/CustomStatusParameters.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParameters.java
@@ -15,7 +15,6 @@ public class CustomStatusParameters<
         C extends TypeSafeMarker,
         I extends TypeSafeMarker
 > {
-//    private final long gpMax;
     private final long sysInfoMax;
     private final long categoryMax;
     private final long instanceDetailMax;
@@ -28,7 +27,6 @@ public class CustomStatusParameters<
     private long instanceBits;
 
     CustomStatusParameters(CustomStatusParametersSupplier supplier) {
-//        this.gpMax = (1L << supplier.generalPurposeBitSize()) - 1;
         this.sysInfoMax = (1L << supplier.systemInfoBitSize()) - 1;
         this.categoryMax = (1L << supplier.categoryBitSize()) - 1;
         this.instanceDetailMax = (1L << supplier.instanceDetailBitSize()) - 1;

--- a/common/src/main/java/nettee/common/status/CustomStatusParameters.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParameters.java
@@ -11,6 +11,13 @@ import static nettee.common.status.exception.StatusCodeErrorCode.CATEGORY_BITS_O
 import static nettee.common.status.exception.StatusCodeErrorCode.INSTANCE_DETAIL_BITS_OVERFLOW;
 import static nettee.common.status.exception.StatusCodeErrorCode.SYS_INFO_OVERFLOW;
 
+/**
+ * {@code long} 타입 이내에서 GP bits, system information bits, category bits, instance detail bits 구간별 사이즈를 커스텀하여
+ * 사용할 수 있도록 일반화한 클래스입니다.
+ *
+ * @param <C> Category bits 입력을 필수로 합니다. (컴파일타임 체크)
+ * @param <I> Instance detail bits 입력을 필수로 합니다. (컴파일타임 체크)
+ */
 public class CustomStatusParameters<
         C extends TypeSafeMarker,
         I extends TypeSafeMarker

--- a/common/src/main/java/nettee/common/status/CustomStatusParameters.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParameters.java
@@ -81,6 +81,18 @@ public class CustomStatusParameters<
         return instance;
     }
 
+    public int generalPurposeBitsShift() {
+        return supplier.systemInfoBitSize() + supplier.categoryBitSize() + supplier.instanceDetailBitSize();
+    }
+
+    public int systemInfoBitsShift() {
+        return supplier.categoryBitSize() + supplier.instanceDetailBitSize();
+    }
+
+    public int categoryBitsShift() {
+        return supplier.instanceDetailBitSize();
+    }
+
     public long generalPurposeBits() {
         return generalPurposeBits;
     }

--- a/common/src/main/java/nettee/common/status/CustomStatusParameters.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParameters.java
@@ -1,0 +1,106 @@
+package nettee.common.status;
+
+import nettee.common.marker.TypeSafeMarker;
+import nettee.common.marker.TypeSafeMarker.Missing;
+import nettee.common.marker.TypeSafeMarker.Present;
+import nettee.common.status.CustomStatusParametersSupplier.LongGeneralPurposeFeaturesValue;
+
+import java.util.Collection;
+
+import static nettee.common.status.exception.StatusCodeErrorCode.CATEGORY_BITS_OVERFLOW;
+import static nettee.common.status.exception.StatusCodeErrorCode.INSTANCE_DETAIL_BITS_OVERFLOW;
+import static nettee.common.status.exception.StatusCodeErrorCode.SYS_INFO_OVERFLOW;
+
+public class CustomStatusParameters<
+        C extends TypeSafeMarker,
+        I extends TypeSafeMarker
+> {
+//    private final long gpMax;
+    private final long sysInfoMax;
+    private final long categoryMax;
+    private final long instanceDetailMax;
+    private final LongGeneralPurposeFeaturesValue featuresBits;
+
+    private long generalPurposeBits;
+    private long systemInfoBits;
+
+    private long categoryBits;
+    private long instanceBits;
+
+    CustomStatusParameters(CustomStatusParametersSupplier supplier) {
+//        this.gpMax = (1L << supplier.generalPurposeBitSize()) - 1;
+        this.sysInfoMax = (1L << supplier.systemInfoBitSize()) - 1;
+        this.categoryMax = (1L << supplier.categoryBitSize()) - 1;
+        this.instanceDetailMax = (1L << supplier.instanceDetailBitSize()) - 1;
+        this.featuresBits = supplier.features();
+    }
+
+    public static CustomStatusParameters<Missing, Missing> generateWith(CustomStatusParametersSupplier supplier) {
+        return new CustomStatusParameters<>(supplier);
+    }
+
+    public CustomStatusParameters<C, I> generalPurposeFeatures(
+            Collection<String> extendedFeatures,
+            LongGeneralPurposeFeatures... features
+    ) {
+        generalPurposeBits = featuresBits.getValueOf(extendedFeatures, features);
+        return this;
+    }
+
+    public CustomStatusParameters<C, I> generalPurposeFeatures(LongGeneralPurposeFeatures... features) {
+        generalPurposeBits = featuresBits.getValueOf(features);
+        return this;
+    }
+
+    public CustomStatusParameters<C, I> systemInfoBits(long systemInfoBits) {
+        if (systemInfoBits > sysInfoMax) {
+            throw SYS_INFO_OVERFLOW.exception();
+        }
+        this.systemInfoBits = systemInfoBits;
+        return this;
+    }
+
+    public CustomStatusParameters<Present, I> categoryBits(long categoryBits) {
+        if (categoryBits > categoryMax) {
+            throw CATEGORY_BITS_OVERFLOW.exception();
+        }
+        this.categoryBits = categoryBits;
+        @SuppressWarnings("unchecked")
+        var instance = (CustomStatusParameters<Present, I>) this;
+        return instance;
+    }
+
+    public CustomStatusParameters<C, Present> instanceBits(long instanceBits) {
+        if (instanceBits > instanceDetailMax) {
+            throw INSTANCE_DETAIL_BITS_OVERFLOW.exception();
+        }
+        this.instanceBits = instanceBits;
+        @SuppressWarnings("unchecked")
+        var instance = (CustomStatusParameters<C, Present>) this;
+        return instance;
+    }
+
+    public long generalPurposeBits() {
+        return generalPurposeBits;
+    }
+
+    public long systemInfoBits() {
+        return systemInfoBits;
+    }
+
+    public long categoryBits() {
+        return categoryBits;
+    }
+
+    public long instanceBits() {
+        return instanceBits;
+    }
+
+    public enum LongGeneralPurposeFeatures {
+        ALL,
+        READ,
+        UPDATE,
+        SUBITEM_READ,
+        SUBITEM_UPDATE
+    }
+}

--- a/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
@@ -13,7 +13,6 @@ import static nettee.common.status.exception.StatusCodeErrorCode.GP_CUSTOM_KEY_N
 import static nettee.common.status.exception.StatusCodeErrorCode.TOTAL_BITS_OVERFLOW;
 
 public final class CustomStatusParametersSupplier implements Supplier<CustomStatusParameters<Missing, Missing>> {
-//    private final int gpSize;
     private final int sysInfoSize;
     private final int categorySize;
     private final int instanceDetailSize;
@@ -35,16 +34,11 @@ public final class CustomStatusParametersSupplier implements Supplier<CustomStat
         // validate that the GP list fits within the GP size.
         featuresBits.validateSize(generalPurposeBitSize);
 
-//        this.gpSize = generalPurposeBitSize;
         this.sysInfoSize = systemInfoBitSize;
         this.categorySize = categoryBitSize;
         this.instanceDetailSize = instanceBitSize;
         this.featuresBits = featuresBits;
     }
-
-//    public int generalPurposeBitSize() {
-//        return gpSize;
-//    }
 
     public int systemInfoBitSize() {
         return sysInfoSize;

--- a/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
@@ -62,8 +62,7 @@ public final class CustomStatusParametersSupplier implements Supplier<CustomStat
     }
 
     /**
-     * 일반 목적 기능(GP features)을 표현하는 독립된 비트 영역을 보존합니다.
-     *
+     * 일반 목적 기능(GP features)을 독립된 비트 영역으로 표현하기 위한 클래스입니다.
      */
     public static final class LongGeneralPurposeFeaturesValue {
         final private long read;
@@ -74,7 +73,6 @@ public final class CustomStatusParametersSupplier implements Supplier<CustomStat
         final private long max;
 
         /**
-         *
          * @param read '일반 조회 목적'을 표현할 비트를 입력합니다.
          * @param update '일반 수정 목적'을 표현할 비트를 입력합니다.
          * @param subItemRead '하위항목 일반 조회 목적'을 표현할 비트를 입력합니다.

--- a/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
+++ b/common/src/main/java/nettee/common/status/CustomStatusParametersSupplier.java
@@ -1,0 +1,188 @@
+package nettee.common.status;
+
+import nettee.common.marker.TypeSafeMarker.Missing;
+import nettee.common.status.CustomStatusParameters.LongGeneralPurposeFeatures;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static nettee.common.status.exception.StatusCodeErrorCode.GP_BITS_NOT_DISTINCT;
+import static nettee.common.status.exception.StatusCodeErrorCode.GP_BITS_OUT_OF_BOUND;
+import static nettee.common.status.exception.StatusCodeErrorCode.GP_CUSTOM_KEY_NOT_CORRECT;
+import static nettee.common.status.exception.StatusCodeErrorCode.TOTAL_BITS_OVERFLOW;
+
+public final class CustomStatusParametersSupplier implements Supplier<CustomStatusParameters<Missing, Missing>> {
+//    private final int gpSize;
+    private final int sysInfoSize;
+    private final int categorySize;
+    private final int instanceDetailSize;
+    private final LongGeneralPurposeFeaturesValue featuresBits;
+
+    public CustomStatusParametersSupplier(
+            int generalPurposeBitSize,
+            int systemInfoBitSize,
+            int categoryBitSize,
+            int instanceBitSize,
+            LongGeneralPurposeFeaturesValue featuresBits
+    ) {
+        // validate the total size
+        int totalSize = generalPurposeBitSize + systemInfoBitSize + categoryBitSize + instanceBitSize;
+        if (totalSize > Long.BYTES * 8) {
+            throw TOTAL_BITS_OVERFLOW.exception();
+        }
+
+        // validate that the GP list fits within the GP size.
+        featuresBits.validateSize(generalPurposeBitSize);
+
+//        this.gpSize = generalPurposeBitSize;
+        this.sysInfoSize = systemInfoBitSize;
+        this.categorySize = categoryBitSize;
+        this.instanceDetailSize = instanceBitSize;
+        this.featuresBits = featuresBits;
+    }
+
+//    public int generalPurposeBitSize() {
+//        return gpSize;
+//    }
+
+    public int systemInfoBitSize() {
+        return sysInfoSize;
+    }
+
+    public int categoryBitSize() {
+        return categorySize;
+    }
+
+    public int instanceDetailBitSize() {
+        return instanceDetailSize;
+    }
+
+    public LongGeneralPurposeFeaturesValue features() {
+        return featuresBits;
+    }
+
+    @Override
+    public CustomStatusParameters<Missing, Missing> get() {
+        return new CustomStatusParameters<>(this);
+    }
+
+    /**
+     * 일반 목적 기능(GP features)을 표현하는 독립된 비트 영역을 보존합니다.
+     *
+     */
+    public static final class LongGeneralPurposeFeaturesValue {
+        final private long read;
+        final private long update;
+        final private long subItemRead;
+        final private long subItemUpdate;
+        final private Map<String, Long> extended;
+        final private long max;
+
+        /**
+         *
+         * @param read '일반 조회 목적'을 표현할 비트를 입력합니다.
+         * @param update '일반 수정 목적'을 표현할 비트를 입력합니다.
+         * @param subItemRead '하위항목 일반 조회 목적'을 표현할 비트를 입력합니다.
+         * @param subItemUpdate '하위항목 일반 수정 목적'을 표현할 비트를 입력합니다.
+         * @param extended 그 외 확장된 목적의 비트를 map 구조로 전달합니다. (Key: String, Value: Long)
+         */
+        public LongGeneralPurposeFeaturesValue(
+                long read,
+                long update,
+                long subItemRead,
+                long subItemUpdate,
+                Map<String, Long> extended
+        ) {
+            long bitsOverlapped = read | update | subItemRead | subItemUpdate;
+            long bitsSum = read + update + subItemRead + subItemUpdate;
+
+            if (bitsOverlapped != bitsSum) {
+                throw GP_BITS_NOT_DISTINCT.exception();
+            }
+
+            if (extended != null && !extended.isEmpty()) {
+                for (var value : extended.values()) {
+                    bitsOverlapped |= value;
+                    bitsSum += value;
+                    if (bitsOverlapped != bitsSum) {
+                        throw GP_BITS_NOT_DISTINCT.exception();
+                    }
+                }
+            }
+
+            this.read = read;
+            this.update = update;
+            this.subItemRead = subItemRead;
+            this.subItemUpdate = subItemUpdate;
+            this.extended = extended;
+            this.max = bitsOverlapped;
+        }
+
+        public long read() {
+            return read;
+        }
+
+        public long update() {
+            return update;
+        }
+
+        public long subItemRead() {
+            return subItemRead;
+        }
+
+        public long subItemUpdate() {
+            return subItemUpdate;
+        }
+
+        public Map<String, Long> extended() {
+            return extended;
+        }
+
+        public long max() {
+            return max;
+        }
+
+        public long getValueOf(Collection<String> extendedKeys, LongGeneralPurposeFeatures... features) {
+            long value = 0;
+
+            for (var extendedKey : extendedKeys) {
+                if (!extended.containsKey(extendedKey)) {
+                    throw GP_CUSTOM_KEY_NOT_CORRECT.exception();
+                }
+
+                value |= extended.get(extendedKey);
+            }
+
+            value |= getValueOf(features);
+
+            return value;
+        }
+
+        public long getValueOf(LongGeneralPurposeFeatures... features) {
+            long value = 0;
+
+            for (var feature : features) {
+                if (feature == LongGeneralPurposeFeatures.ALL || value == max) {
+                    return max;
+                }
+
+                value |= switch (feature) {
+                    case READ -> read;
+                    case UPDATE -> update;
+                    case SUBITEM_READ -> subItemRead;
+                    case SUBITEM_UPDATE -> subItemUpdate;
+                    default -> throw new Error("");
+                };
+            }
+
+            return value;
+        }
+
+        public void validateSize(int size) {
+            if (max >= (1L << size)) {
+                throw GP_BITS_OUT_OF_BOUND.exception();
+            }
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/status/StatusCodeConstants.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeConstants.java
@@ -11,8 +11,9 @@ public final class StatusCodeConstants {
         public static final int CATEGORY_BIT_SIZE = 8;
         public static final int INSTANCE_DETAIL_BIT_SIZE = 8;
 
-        public static final int GENERAL_PURPOSE_SHIFT = 24;
-        public static final int SYSTEM_INFORMATION_SHIFT = 16;
-        public static final int CATEGORY_SHIFT = 8;
+        public static final int GENERAL_PURPOSE_SHIFT =
+                SYSTEM_INFORMATION_BIT_SIZE + CATEGORY_BIT_SIZE + INSTANCE_DETAIL_BIT_SIZE;
+        public static final int SYSTEM_INFORMATION_SHIFT = CATEGORY_BIT_SIZE + INSTANCE_DETAIL_BIT_SIZE;
+        public static final int CATEGORY_SHIFT = INSTANCE_DETAIL_BIT_SIZE;
     }
 }

--- a/common/src/main/java/nettee/common/status/StatusCodeConstants.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeConstants.java
@@ -1,0 +1,18 @@
+package nettee.common.status;
+
+public final class StatusCodeConstants {
+    private StatusCodeConstants() {}
+
+    public static final class Default {
+        private Default() {}
+
+        public static final int GENERAL_PURPOSE_BIT_SIZE = 7;
+        public static final int SYSTEM_INFORMATION_BIT_SIZE = 8;
+        public static final int CATEGORY_BIT_SIZE = 8;
+        public static final int INSTANCE_DETAIL_BIT_SIZE = 8;
+
+        public static final int GENERAL_PURPOSE_SHIFT = 24;
+        public static final int SYSTEM_INFORMATION_SHIFT = 16;
+        public static final int CATEGORY_SHIFT = 8;
+    }
+}

--- a/common/src/main/java/nettee/common/status/StatusCodeUtil.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeUtil.java
@@ -2,13 +2,17 @@ package nettee.common.status;
 
 import nettee.common.marker.TypeSafeMarker.Present;
 
+import static nettee.common.status.StatusCodeConstants.Default.CATEGORY_SHIFT;
+import static nettee.common.status.StatusCodeConstants.Default.GENERAL_PURPOSE_SHIFT;
+import static nettee.common.status.StatusCodeConstants.Default.SYSTEM_INFORMATION_SHIFT;
+
 public final class StatusCodeUtil {
     private StatusCodeUtil() {}
 
     public static int getAsInt(StatusParameters<Present, Present> parameters) {
-        return (parameters.generalPurposeBits() << 24)
-                | (parameters.systemInfoBits() << 16)
-                | (parameters.categoryBits() << 8)
+        return (parameters.generalPurposeBits() << GENERAL_PURPOSE_SHIFT)
+                | (parameters.systemInfoBits() << SYSTEM_INFORMATION_SHIFT)
+                | (parameters.categoryBits() << CATEGORY_SHIFT)
                 | parameters.instanceBits();
     }
 }

--- a/common/src/main/java/nettee/common/status/StatusCodeUtil.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeUtil.java
@@ -15,4 +15,9 @@ public final class StatusCodeUtil {
                 | (parameters.categoryBits() << CATEGORY_SHIFT)
                 | parameters.instanceBits();
     }
+
+    // TODO
+//    public static long getAsLong(CustomStatusParameters<Present, Present> parameters) {
+//        // ...
+//    }
 }

--- a/common/src/main/java/nettee/common/status/StatusCodeUtil.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeUtil.java
@@ -16,8 +16,14 @@ public final class StatusCodeUtil {
                 | parameters.instanceBits();
     }
 
-    // TODO
-//    public static long getAsLong(CustomStatusParameters<Present, Present> parameters) {
-//        // ...
-//    }
+    public static long getAsLong(CustomStatusParameters<Present, Present> parameters) {
+        int gpShift = parameters.generalPurposeBitsShift();
+        int sysShift = parameters.systemInfoBitsShift();
+        int cateShift = parameters.categoryBitsShift();
+
+        return (parameters.generalPurposeBits() << gpShift)
+                | (parameters.systemInfoBits() << sysShift)
+                | (parameters.categoryBits() << cateShift)
+                | parameters.instanceBits();
+    }
 }

--- a/common/src/main/java/nettee/common/status/StatusCodeUtil.java
+++ b/common/src/main/java/nettee/common/status/StatusCodeUtil.java
@@ -1,0 +1,14 @@
+package nettee.common.status;
+
+import nettee.common.marker.TypeSafeMarker.Present;
+
+public final class StatusCodeUtil {
+    private StatusCodeUtil() {}
+
+    public static int getAsInt(StatusParameters<Present, Present> parameters) {
+        return (parameters.generalPurposeBits() << 24)
+                | (parameters.systemInfoBits() << 16)
+                | (parameters.categoryBits() << 8)
+                | parameters.instanceBits();
+    }
+}

--- a/common/src/main/java/nettee/common/status/StatusParameters.java
+++ b/common/src/main/java/nettee/common/status/StatusParameters.java
@@ -1,0 +1,79 @@
+package nettee.common.status;
+
+import nettee.common.marker.TypeSafeMarker;
+import nettee.common.marker.TypeSafeMarker.Missing;
+import nettee.common.marker.TypeSafeMarker.Present;
+
+public class StatusParameters<
+        C extends TypeSafeMarker,
+        I extends TypeSafeMarker
+> {
+    private int generalPurposeBits;
+    private int systemInfoBits;
+
+    private int categoryBits;
+    private int instanceBits;
+
+    private StatusParameters() {}
+
+    public static StatusParameters<Missing, Missing> generate() {
+        return new StatusParameters<>();
+    }
+
+    public StatusParameters<C, I> generalPurposeFeatures(GeneralPurposeFeatures... features) {
+        generalPurposeBits = 0;
+        for (var feature : features) {
+            generalPurposeBits |= feature.bit;
+        }
+        return this;
+    }
+
+    public StatusParameters<C, I> systemInfoBits(int systemInfoBits) {
+        this.systemInfoBits = systemInfoBits;
+        return this;
+    }
+
+    public StatusParameters<Present, I> categoryBits(int categoryBits) {
+        this.categoryBits = categoryBits;
+        @SuppressWarnings("unchecked")
+        var instance = (StatusParameters<Present, I>) this;
+        return instance;
+    }
+
+    public StatusParameters<C, Present> instanceBits(int instanceBits) {
+        this.instanceBits = instanceBits;
+        @SuppressWarnings("unchecked")
+        var instance = (StatusParameters<C, Present>) this;
+        return instance;
+    }
+
+    public int generalPurposeBits() {
+        return generalPurposeBits;
+    }
+
+    public int systemInfoBits() {
+        return systemInfoBits;
+    }
+
+    public int categoryBits() {
+        return categoryBits;
+    }
+
+    public int instanceBits() {
+        return instanceBits;
+    }
+
+    public enum GeneralPurposeFeatures {
+        ALL(0b110_1100),
+        READ(0b100_0000),
+        UPDATE(0b010_0000),
+        SUBITEM_READ(0b000_1000),
+        SUBITEM_UPDATE(0b000_0100);
+
+        private final int bit;
+
+        GeneralPurposeFeatures(int bit) {
+            this.bit = bit;
+        }
+    }
+}

--- a/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
+++ b/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
@@ -1,0 +1,71 @@
+package nettee.common.status.exception;
+
+import nettee.common.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public enum StatusCodeErrorCode implements ErrorCode {
+    GP_BITS_OUT_OF_BOUND(
+            "설정한 general purpose 비트가 허용 비트 범위를 벗어납니다.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    GP_BITS_NOT_DISTINCT(
+            "Each input value must correspond to a distinct, non-overlapping bit.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    TOTAL_BITS_OVERFLOW(
+            "각 영역의 크기 합이 %d 비트 이하여야 합니다.".formatted(Long.BYTES * 8),
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    ;
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    StatusCodeErrorCode(String message, HttpStatus httpStatus) {
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public StatusCodeException exception() {
+        return new StatusCodeException(this);
+    }
+
+    @Override
+    public StatusCodeException exception(Throwable cause) {
+        return new StatusCodeException(this, cause);
+    }
+
+    @Override
+    public StatusCodeException exception(Runnable runnable) {
+        return new StatusCodeException(this, runnable);
+    }
+
+    @Override
+    public StatusCodeException exception(Runnable runnable, Throwable cause) {
+        return new StatusCodeException(this, runnable, cause);
+    }
+
+    @Override
+    public StatusCodeException exception(Supplier<Map<String, Object>> appendPayload) {
+        return new StatusCodeException(this, appendPayload);
+    }
+
+    @Override
+    public StatusCodeException exception(Supplier<Map<String, Object>> appendPayload, Throwable cause) {
+        return new StatusCodeException(this, appendPayload, cause);
+    }
+}

--- a/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
+++ b/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
@@ -12,11 +12,27 @@ public enum StatusCodeErrorCode implements ErrorCode {
             HttpStatus.INTERNAL_SERVER_ERROR
     ),
     GP_BITS_OUT_OF_BOUND(
-            "설정한 general purpose 비트가 허용 비트 범위를 벗어납니다.",
+            "설정한 general purpose 비트가 입력 허용 비트 범위를 벗어납니다.",
             HttpStatus.INTERNAL_SERVER_ERROR
     ),
     GP_BITS_NOT_DISTINCT(
             "Each input value must correspond to a distinct, non-overlapping bit.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    GP_CUSTOM_KEY_NOT_CORRECT(
+            "정확한 GP 커스텀 이름을 입력하세요.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    SYS_INFO_OVERFLOW(
+            "System information 비트가 입력 허용 비트 범위를 벗어납니다.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    CATEGORY_BITS_OVERFLOW(
+            "Category 비트가 입력 허용 비트 범위를 벗어납니다.",
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
+    INSTANCE_DETAIL_BITS_OVERFLOW(
+            "Instance detail 비트가 입력 허용 비트 범위를 벗어납니다.",
             HttpStatus.INTERNAL_SERVER_ERROR
     ),
     ;

--- a/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
+++ b/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
@@ -34,8 +34,7 @@ public enum StatusCodeErrorCode implements ErrorCode {
     INSTANCE_DETAIL_BITS_OVERFLOW(
             "Instance detail 비트가 입력 허용 비트 범위를 벗어납니다.",
             HttpStatus.INTERNAL_SERVER_ERROR
-    ),
-    ;
+    );
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
+++ b/common/src/main/java/nettee/common/status/exception/StatusCodeErrorCode.java
@@ -7,16 +7,16 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public enum StatusCodeErrorCode implements ErrorCode {
+    TOTAL_BITS_OVERFLOW(
+            "각 영역의 크기 합이 %d 비트 이하여야 합니다.".formatted(Long.BYTES * 8),
+            HttpStatus.INTERNAL_SERVER_ERROR
+    ),
     GP_BITS_OUT_OF_BOUND(
             "설정한 general purpose 비트가 허용 비트 범위를 벗어납니다.",
             HttpStatus.INTERNAL_SERVER_ERROR
     ),
     GP_BITS_NOT_DISTINCT(
             "Each input value must correspond to a distinct, non-overlapping bit.",
-            HttpStatus.INTERNAL_SERVER_ERROR
-    ),
-    TOTAL_BITS_OVERFLOW(
-            "각 영역의 크기 합이 %d 비트 이하여야 합니다.".formatted(Long.BYTES * 8),
             HttpStatus.INTERNAL_SERVER_ERROR
     ),
     ;

--- a/common/src/main/java/nettee/common/status/exception/StatusCodeException.java
+++ b/common/src/main/java/nettee/common/status/exception/StatusCodeException.java
@@ -1,0 +1,33 @@
+package nettee.common.status.exception;
+
+import nettee.common.CustomException;
+import nettee.common.ErrorCode;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class StatusCodeException extends CustomException {
+    public StatusCodeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public StatusCodeException(ErrorCode errorCode, Throwable cause) {
+        super(errorCode, cause);
+    }
+
+    public StatusCodeException(ErrorCode errorCode, Runnable runnable) {
+        super(errorCode, runnable);
+    }
+
+    public StatusCodeException(ErrorCode errorCode, Runnable runnable, Throwable cause) {
+        super(errorCode, runnable, cause);
+    }
+
+    public StatusCodeException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier) {
+        super(errorCode, payloadSupplier);
+    }
+
+    public StatusCodeException(ErrorCode errorCode, Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        super(errorCode, payloadSupplier, cause);
+    }
+}

--- a/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
+++ b/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
@@ -104,4 +104,104 @@ class StatusCodeUtilTest: FreeSpec({
             code shouldBe 0x00_FF_00_00
         }
     }
+
+    "[CATEGORY] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
+        "CATEGORY: 0" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_00
+        }
+
+        "CATEGORY: 0x0F" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0x0F)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_0F_00
+        }
+
+        "CATEGORY: 0x55" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0x55)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_55_00
+        }
+
+        "CATEGORY: 0xFF" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0xFF)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_FF_00
+        }
+    }
+
+    "[INSTANCE DETAIL] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
+        "INSTANCE DETAIL: 0" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_00
+        }
+
+        "INSTANCE DETAIL: 0x0F" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0x0F)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_0F
+        }
+
+        "INSTANCE DETAIL: 0x55" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0x55)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_55
+        }
+
+        "INSTANCE DETAIL: 0xFF" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0xFF)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_FF
+        }
+    }
 })

--- a/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
+++ b/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
@@ -1,0 +1,45 @@
+package nettee.common.status
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import nettee.common.status.StatusParameters.GeneralPurposeFeatures.*
+
+class StatusCodeUtilTest: FreeSpec({
+    "[GP] 다른 섹션이 모두 0일 때" - {
+        val cases = listOf(
+            // Single GP
+            setOf(READ) to 0x40_00_00_00,
+            setOf(UPDATE) to 0x20_00_00_00,
+            setOf(SUBITEM_READ) to 0x08_00_00_00,
+            setOf(SUBITEM_UPDATE) to 0x04_00_00_00,
+
+            // 2 GP items
+            setOf(READ, UPDATE) to 0x60_00_00_00,
+            setOf(READ, SUBITEM_READ) to 0x48_00_00_00,
+            setOf(READ, SUBITEM_UPDATE) to 0x44_00_00_00,
+            setOf(UPDATE, SUBITEM_READ) to 0x28_00_00_00,
+            setOf(UPDATE, SUBITEM_UPDATE) to 0x24_00_00_00,
+            setOf(SUBITEM_READ, SUBITEM_UPDATE) to 0x0C_00_00_00,
+
+            // 3 GP items
+            setOf(READ, UPDATE, SUBITEM_READ) to 0x68_00_00_00,
+            setOf(READ, UPDATE, SUBITEM_UPDATE) to 0x64_00_00_00,
+            setOf(READ, SUBITEM_READ, SUBITEM_UPDATE) to 0x4C_00_00_00,
+            setOf(UPDATE, SUBITEM_READ, SUBITEM_UPDATE) to 0x2C_00_00_00,
+        )
+
+        cases.forEach { (features, expectedCode) ->
+            "GP: ${features.joinToString()}" {
+                val parameters = StatusParameters.generate()
+                    .generalPurposeFeatures(*features.toTypedArray())
+                    .systemInfoBits(0)
+                    .categoryBits(0)
+                    .instanceBits(0)
+
+                val code = StatusCodeUtil.getAsInt(parameters)
+
+                code shouldBe expectedCode
+            }
+        }
+    }
+})

--- a/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
+++ b/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
@@ -1,11 +1,23 @@
 package nettee.common.status
 
 import io.kotest.core.spec.style.FreeSpec
-import io.kotest.matchers.shouldBe
+import io.kotest.matchers.*
 import nettee.common.status.StatusParameters.GeneralPurposeFeatures.*
 
 class StatusCodeUtilTest: FreeSpec({
     "[GP] 다른 섹션이 모두 0일 때" - {
+        "GP: NO OP" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0
+        }
+
         val cases = listOf(
             // Single GP
             setOf(READ) to 0x40_00_00_00,
@@ -40,6 +52,56 @@ class StatusCodeUtilTest: FreeSpec({
 
                 code shouldBe expectedCode
             }
+        }
+    }
+
+    "[SYS INFO BITS] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
+        "SYS INFO: 0" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_00_00_00
+        }
+
+        "SYS INFO: 0x0F" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0x0F)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_0F_00_00
+        }
+
+        "SYS INFO: 0x55" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0x55)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_55_00_00
+        }
+
+        "SYS INFO: 0xFF" {
+            val parameters = StatusParameters.generate()
+                .generalPurposeFeatures()
+                .systemInfoBits(0xFF)
+                .categoryBits(0)
+                .instanceBits(0)
+
+            val code = StatusCodeUtil.getAsInt(parameters)
+
+            code shouldBe 0x00_FF_00_00
         }
     }
 })

--- a/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
+++ b/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest.kt
@@ -56,152 +56,71 @@ class StatusCodeUtilTest: FreeSpec({
     }
 
     "[SYS INFO BITS] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
-        "SYS INFO: 0" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0)
+        val cases = listOf(
+            0x00 to 0x00_00_00_00,
+            0x0F to 0x00_0F_00_00,
+            0x55 to 0x00_55_00_00,
+            0xFF to 0x00_FF_00_00,
+        )
 
-            val code = StatusCodeUtil.getAsInt(parameters)
+        cases.forEach { (input, expectedCode) ->
+            "SYS INFO: $input" {
+                val parameters = StatusParameters.generate()
+                    .generalPurposeFeatures()
+                    .systemInfoBits(input)
+                    .categoryBits(0)
+                    .instanceBits(0)
 
-            code shouldBe 0x00_00_00_00
-        }
+                val code = StatusCodeUtil.getAsInt(parameters)
 
-        "SYS INFO: 0x0F" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0x0F)
-                .categoryBits(0)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_0F_00_00
-        }
-
-        "SYS INFO: 0x55" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0x55)
-                .categoryBits(0)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_55_00_00
-        }
-
-        "SYS INFO: 0xFF" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0xFF)
-                .categoryBits(0)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_FF_00_00
+                code shouldBe expectedCode
+            }
         }
     }
 
     "[CATEGORY] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
-        "CATEGORY: 0" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0)
+        val cases = listOf(
+            0x00 to 0x00_00_00_00,
+            0x0F to 0x00_00_0F_00,
+            0x55 to 0x00_00_55_00,
+            0xFF to 0x00_00_FF_00,
+        )
 
-            val code = StatusCodeUtil.getAsInt(parameters)
+        cases.forEach { (input, expectedCode) ->
+            "CATEGORY: $input" {
+                val parameters = StatusParameters.generate()
+                    .generalPurposeFeatures()
+                    .systemInfoBits(0)
+                    .categoryBits(input)
+                    .instanceBits(0)
 
-            code shouldBe 0x00_00_00_00
-        }
+                val code = StatusCodeUtil.getAsInt(parameters)
 
-        "CATEGORY: 0x0F" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0x0F)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_0F_00
-        }
-
-        "CATEGORY: 0x55" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0x55)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_55_00
-        }
-
-        "CATEGORY: 0xFF" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0xFF)
-                .instanceBits(0)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_FF_00
+                code shouldBe expectedCode
+            }
         }
     }
 
     "[INSTANCE DETAIL] 다른 섹션이 모두 0일 때 입력한 비트가 알맞은 위치에 대입된다." - {
-        "INSTANCE DETAIL: 0" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0)
+        val cases = listOf(
+            0x00 to 0x00_00_00_00,
+            0x0F to 0x00_00_00_0F,
+            0x55 to 0x00_00_00_55,
+            0xFF to 0x00_00_00_FF,
+        )
 
-            val code = StatusCodeUtil.getAsInt(parameters)
+        cases.forEach { (input, expectedCode) ->
+            "INSTANCE DETAIL: $input" {
+                val parameters = StatusParameters.generate()
+                    .generalPurposeFeatures()
+                    .systemInfoBits(0)
+                    .categoryBits(0)
+                    .instanceBits(input)
 
-            code shouldBe 0x00_00_00_00
-        }
+                val code = StatusCodeUtil.getAsInt(parameters)
 
-        "INSTANCE DETAIL: 0x0F" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0x0F)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_00_0F
-        }
-
-        "INSTANCE DETAIL: 0x55" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0x55)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_00_55
-        }
-
-        "INSTANCE DETAIL: 0xFF" {
-            val parameters = StatusParameters.generate()
-                .generalPurposeFeatures()
-                .systemInfoBits(0)
-                .categoryBits(0)
-                .instanceBits(0xFF)
-
-            val code = StatusCodeUtil.getAsInt(parameters)
-
-            code shouldBe 0x00_00_00_FF
+                code shouldBe expectedCode
+            }
         }
     }
 })

--- a/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest_CustomStatusParameters.kt
+++ b/common/src/test/kotlin/nettee/common/status/StatusCodeUtilTest_CustomStatusParameters.kt
@@ -1,0 +1,100 @@
+package nettee.common.status
+
+import io.kotest.assertions.throwables.*
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.*
+import nettee.common.status.CustomStatusParametersSupplier.LongGeneralPurposeFeaturesValue
+import nettee.common.status.CustomStatusParameters.LongGeneralPurposeFeatures.*
+import nettee.common.status.exception.StatusCodeException
+import nettee.common.status.exception.StatusCodeErrorCode.*
+
+class StatusCodeUtilTest_CustomStatusParameters: FreeSpec({
+    "[복합]" - {
+        "GP: 중복 없음." {
+            val featureValues = LongGeneralPurposeFeaturesValue(
+                0b100_0000__0000_0000____0000_0000__0000_0000L,
+                0b010_0000__0000_0000____0000_0000__0000_0000L,
+                0b000_0000__0000_0000____1000_0000__0000_0000L,
+                0b000_0000__0000_0000____0100_0000__0000_0000L,
+                mapOf(
+                    "example1" to 0b000_1000__0000_0000____0000_0000__0000_0000L,
+                    "example2" to 0b000_0100__0000_0000____0000_0000__0000_0000L,
+                    "example3" to 0b000_0010__0000_0000____0000_0000__0000_0000L,
+                )
+            )
+
+            val supplier = CustomStatusParametersSupplier(
+                31,
+                16,
+                8,
+                8,
+                featureValues
+            ).get()
+
+            val parameters = supplier
+                .generalPurposeFeatures(
+                    listOf("example1", "example2", "example3"),
+                    READ,
+                    UPDATE
+                )
+                .systemInfoBits(2)
+                .categoryBits(1)
+                .instanceBits(4)
+
+            val code = StatusCodeUtil.getAsLong(parameters)
+
+            code shouldBe 0x6E_00_00_00____0002____01____04L
+        }
+    }
+
+    "[GP] GP 중복" - {
+        "기본 GP 범위 중복 시" - {
+            val read = 0b110_0000__0000_0000____0000_0000__0000_0000L
+            val update = 0b010_0000__0000_0000____0000_0000__0000_0000L
+            val subItemRead = 0b000_0000__0000_0000____1000_0000__0000_0000L
+            val subItemUpdate = 0b000_0000__0000_0000____0100_0000__0000_0000L
+            val featureValues = mapOf(
+                "example1" to 0b000_1000__0000_0000____0000_0000__0000_0000L,
+                "example2" to 0b000_0100__0000_0000____0000_0000__0000_0000L,
+                "example3" to 0b000_0010__0000_0000____0000_0000__0000_0000L,
+            )
+            "StatusCodeException" {
+                shouldThrow<StatusCodeException> {
+                    LongGeneralPurposeFeaturesValue(
+                        read,
+                        update,
+                        subItemRead,
+                        subItemUpdate,
+                        featureValues,
+                    )
+                }
+            }
+        }
+
+        "GP: 커스텀 GP 범위 중복 시 StatusCodeException" - {
+            val read = 0b110_0000__0000_0000____0000_0000__0000_0000L
+            val update = 0b010_0000__0000_0000____0000_0000__0000_0000L
+            val subItemRead = 0b000_0000__0000_0000____1000_0000__0000_0000L
+            val subItemUpdate = 0b000_0000__0000_0000____0100_0000__0000_0000L
+            val featureValues = mapOf(
+                "example1" to 0b000_1000__0000_0000____0000_0000__0000_0000L,
+                "example2" to 0b000_1100__0000_0000____0000_0000__0000_0000L,
+                "example3" to 0b000_1110__0000_0000____0000_0000__0000_0000L,
+            )
+
+            "StatusCodeException" {
+                val exception = shouldThrow<StatusCodeException> {
+                    LongGeneralPurposeFeaturesValue(
+                        read,
+                        update,
+                        subItemRead,
+                        subItemUpdate,
+                        featureValues,
+                    )
+                }
+
+                exception.errorCode shouldBe GP_BITS_NOT_DISTINCT
+            }
+        }
+    }
+})

--- a/services/board/api/exception/src/main/java/nettee/board/exception/BoardErrorCode.java
+++ b/services/board/api/exception/src/main/java/nettee/board/exception/BoardErrorCode.java
@@ -10,8 +10,9 @@ public enum BoardErrorCode implements ErrorCode {
     BOARD_NOT_FOUND("게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     BOARD_GONE("더 이상 존재하지 않는 게시물입니다.", HttpStatus.GONE),
     BOARD_FORBIDDEN("권한이 없습니다.", HttpStatus.FORBIDDEN),
-    DEFAULT("게시물 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR),
-    BOARD_ALREADY_EXIST("게시물이 이미 존재합니다.", HttpStatus.CONFLICT);
+    BOARD_ALREADY_EXIST("게시물이 이미 존재합니다.", HttpStatus.CONFLICT),
+    UNMAPPED_BOARD_STATUS("Unknown board status or its code.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DEFAULT("게시물 조작 오류", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
+++ b/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
@@ -40,7 +40,7 @@ public enum BoardEntityStatus {
                             GeneralPurposeFeatures.READ,
                             GeneralPurposeFeatures.SUBITEM_READ
                     )
-                    .categoryBits(0b0000_0000_0000_01000)
+                    .categoryBits(0b0000_0000_0000_0100)
                     .instanceBits(0)
     );
 

--- a/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
+++ b/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
@@ -1,6 +1,9 @@
 package nettee.board.driven.rdb.entity.type;
 
 import nettee.board.domain.type.BoardStatus;
+import nettee.common.marker.TypeSafeMarker;
+import nettee.common.marker.TypeSafeMarker.Missing;
+import nettee.common.marker.TypeSafeMarker.Present;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -93,7 +96,10 @@ public enum BoardEntityStatus {
         };
     }
 
-    static class SemanticCodeParameters<HAS_CAN_READ, HAS_CLASSIFYING_BITS> {
+    static class SemanticCodeParameters<
+            HAS_CAN_READ extends TypeSafeMarker,
+            HAS_CLASSIFYING_BITS extends TypeSafeMarker> {
+
         boolean canRead;
         Integer classifyingBits;
         int detailBits;
@@ -118,11 +124,5 @@ public enum BoardEntityStatus {
             this.detailBits = detailBits;
             return this;
         }
-
     }
-
-    // NOTE move to other module after its place is determined
-    // Marker interfaces
-    interface Missing {}
-    interface Present {}
 }

--- a/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
+++ b/services/board/driven/rdb/src/main/java/nettee/board/driven/rdb/entity/type/BoardEntityStatus.java
@@ -1,71 +1,62 @@
 package nettee.board.driven.rdb.entity.type;
 
 import nettee.board.domain.type.BoardStatus;
-import nettee.common.marker.TypeSafeMarker;
-import nettee.common.marker.TypeSafeMarker.Missing;
 import nettee.common.marker.TypeSafeMarker.Present;
+import nettee.common.status.StatusCodeUtil;
+import nettee.common.status.StatusParameters;
+import nettee.common.status.StatusParameters.GeneralPurposeFeatures;
+import nettee.common.util.EnumUtil;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static nettee.board.exception.BoardErrorCode.DEFAULT;
+import static nettee.board.exception.BoardErrorCode.UNMAPPED_BOARD_STATUS;
 
 public enum BoardEntityStatus {
     REMOVED(
-            SemanticCodeParameters.builder()
-                    .canRead(false)
-                    .classifyingBits(0b0000_0000_0000_0000)
+            StatusParameters.generate()
+                    .generalPurposeFeatures(
+                            GeneralPurposeFeatures.READ,
+                            GeneralPurposeFeatures.SUBITEM_READ
+                    )
+                    .categoryBits(0b0000_0000_0000_0000)
+                    .instanceBits(0)
     ),
     PENDING(
-            SemanticCodeParameters.builder()
-                    .canRead(false)
-                    .classifyingBits(0b0000_0000_0000_0001)
+            StatusParameters.generate()
+                    .categoryBits(0b0000_0000_0000_0001)
+                    .instanceBits(0)
     ),
     ACTIVE(
-            SemanticCodeParameters.builder()
-                    .canRead(true)
-                    .classifyingBits(0b0000_0000_0000_0010)
+            StatusParameters.generate()
+                    .generalPurposeFeatures(GeneralPurposeFeatures.ALL)
+                    .categoryBits(0b0000_0000_0000_0010)
+                    .instanceBits(0)
     ),
     SUSPENDED(
-            SemanticCodeParameters.builder()
-                    .canRead(true)
-                    .classifyingBits(0b0000_0000_0000_0100)
+            StatusParameters.generate()
+                    .generalPurposeFeatures(
+                            GeneralPurposeFeatures.READ,
+                            GeneralPurposeFeatures.SUBITEM_READ
+                    )
+                    .categoryBits(0b0000_0000_0000_01000)
+                    .instanceBits(0)
     );
-
-    /*
-    R000 0000 0000 0000 0PPP PPPP PPPP PPPP
-      R: generally readable status (1: readable, 0: unreadable)
-      0: classifying bits (16 bits)
-      P: detailed or padded bits (15 bits)
-     */
-    private static final int TLB_PADDING_SIZE = 31;
-    private static final int CLASSIFYING_PADDING_SIZE = 15;
 
     private final int code;
 
     static {
-        // NOTE util 함수가 추가되면 리팩토링
-        assert Arrays.stream(values())
-                .map(BoardEntityStatus::getCode)
-                .collect(Collectors.toSet())
-                .size()
-                == values().length
+        assert EnumUtil.isUniqueAllOf(BoardEntityStatus.class, BoardEntityStatus::getCode)
                 : "BoardEntityStatus의 모든 code 필드가 고유해야 합니다.";
     }
 
-    BoardEntityStatus(SemanticCodeParameters<Present, Present> semanticCodeParameters) {
-        this(
-                semanticCodeParameters.canRead,
-                semanticCodeParameters.classifyingBits,
-                semanticCodeParameters.detailBits
-        );
+    BoardEntityStatus(StatusParameters<Present, Present> semanticCodeParameters) {
+        this(StatusCodeUtil.getAsInt(semanticCodeParameters));
     }
 
-    BoardEntityStatus(boolean canRead, int classifyingBits, int detailBits) {
-        this.code = (canRead ? 1 << TLB_PADDING_SIZE : 0)
-                | (classifyingBits << CLASSIFYING_PADDING_SIZE)
-                | detailBits;
+    BoardEntityStatus(int code) {
+        this.code = code;
     }
 
     public int getCode() {
@@ -75,54 +66,32 @@ public enum BoardEntityStatus {
     public static BoardEntityStatus valueOf(BoardStatus boardStatus) {
         assert Set.of(BoardStatus.REMOVED, BoardStatus.PENDING, BoardStatus.ACTIVE, BoardStatus.SUSPENDED)
                 .containsAll(Arrays.stream(BoardStatus.values()).collect(Collectors.toSet()))
-                : "BoardStatus 중 일부가 BoardEntityStatus::valueOf 함수에서 매핑되지 않습니다.";
+                : "BoardStatus 중 일부가 BoardEntityStatus 인스턴스에 매핑되지 않습니다.";
 
         return switch (boardStatus){
             case REMOVED -> REMOVED;
             case PENDING -> PENDING;
             case ACTIVE -> ACTIVE;
             case SUSPENDED -> SUSPENDED;
-            default -> throw new Error("BoardStatus 중 일부가 BoardEntityStatus::valueOf 함수에서 매핑되지 않습니다.");
+            default -> throw new Error("BoardStatus 중 일부가 BoardEntityStatus 인스턴스에 매핑되지 않습니다.");
         };
     }
 
     public static BoardEntityStatus valueOf(int value) {
         return switch (value) {
-            case 0b0__0000_0000_0000_0000__000_0000_0000_0000 -> REMOVED;
-            case 0b0__0000_0000_0000_0001__000_0000_0000_0000 -> PENDING;
-            case 0b1__0000_0000_0000_0010__000_0000_0000_0000 -> ACTIVE;
-            case 0b1__0000_0000_0000_0100__000_0000_0000_0000 -> SUSPENDED;
-            default -> throw DEFAULT.exception();
+            /*
+             * ø: 부호 비트 (사용 안 함)
+             * X: 기능 비트 (일반 목적 비트)
+             * S: System info bits
+             * C: Category bits
+             * I: Instance detail bits
+
+                   ø_XXX_XXXX__SSSS_SSSS__CCCC_CCCC__IIII_IIII */
+            case 0b0_100_1000__0000_0000__0000_0000__0000_0000 -> REMOVED;
+            case 0b0_000_0000__0000_0000__0000_0001__0000_0000 -> PENDING;
+            case 0b0_110_1100__0000_0000__0000_0010__0000_0000 -> ACTIVE;
+            case 0b0_100_1000__0000_0000__0000_0100__0000_0000 -> SUSPENDED;
+            default -> throw UNMAPPED_BOARD_STATUS.exception();
         };
-    }
-
-    static class SemanticCodeParameters<
-            HAS_CAN_READ extends TypeSafeMarker,
-            HAS_CLASSIFYING_BITS extends TypeSafeMarker> {
-
-        boolean canRead;
-        Integer classifyingBits;
-        int detailBits;
-
-        private SemanticCodeParameters() {}
-
-        public static SemanticCodeParameters<Missing, Missing> builder() {
-            return new SemanticCodeParameters<>();
-        }
-
-        SemanticCodeParameters<HAS_CAN_READ, Present> classifyingBits(Integer classifyingBits) {
-            this.classifyingBits = classifyingBits;
-            return (SemanticCodeParameters<HAS_CAN_READ, Present>) this;
-        }
-
-        SemanticCodeParameters<Present, HAS_CLASSIFYING_BITS> canRead(boolean canRead) {
-            this.canRead = canRead;
-            return (SemanticCodeParameters<Present, HAS_CLASSIFYING_BITS>) this;
-        }
-
-        SemanticCodeParameters<HAS_CAN_READ, HAS_CLASSIFYING_BITS> detailBits(int detailBits) {
-            this.detailBits = detailBits;
-            return this;
-        }
     }
 }


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #55 

## Description

**우리가 사용할 3개 주요 아이템 작업에 집중해 주시면 좋습니다.**

### 1. Type-Safe Markers

JDK 17 `sealed` 인터페이스와 마커 클래스를 만들어 활용합니다.

```java
public sealed interface TypeSafeMarker permits TypeSafeMarker.Present, TypeSafeMarker.Missing {
    final class Present implements TypeSafeMarker { private Present() {} }
    final class Missing implements TypeSafeMarker { private Missing() {} }
}
```

### 2, 3. Entity Status Code

| Sign Bit | General Purpose Bits | System Info Bits | Category Bits | Instance Detail Bits |
|:--:|:--:|:--:|:--:|:--:|
| 1 bit (ø) | 7 bits | 8 bits | 8 bits | 8 bits |

<details open><summary><b>Example Use Case</b></summary>
<p>

```java
var parameters = StatusParameters.generate()
        .generalPurposeFeatures(
                GeneralPurposeFeatures.READ,
                GeneralPurposeFeatures.UPDATE
        )
        .systemInfoBits(0)
        .categoryBits(0)
        .instanceBits(0);

int code = StatusCodeUtil.getAsInt(parameters);
```

</p>
</details> 

- `StatusParameters`: 의미를 담은 코드 값을 생성하는 기본 전략을 적용한 파라미터 객체입니다.  
  - (참고) 다음 열거 상수를 포함합니다.  
    ```java
    public enum GeneralPurposeFeatures {
        ALL(0b110_1100),
        READ(0b100_0000),
        UPDATE(0b010_0000),
        SUBITEM_READ(0b000_1000),
        SUBITEM_UPDATE(0b000_0100);
    
        private final int bit;
    
        GeneralPurposeFeatures(int bit) {
            this.bit = bit;
        }
    }
    ```
- `StatusCodeUtil`: 이하 `StatusParameters` 인스턴스를 정수 코드 값으로 산출해 줍니다.
  - 필수 입력 필드를 채운 `StatusParameters` 인스턴스만 입력받습니다. (제네릭 활용)

### Others

이하 항목은 각 비트 섹션의 크기를 커스텀할 수 있도록 추가한 `long` 타입 코드 생성 클래스들입니다.
코드리뷰에서 집중하지 않아도 되는 부분이라고 생각합니다.

- `CustomStatusParameters`
- `CustomStatusParametersSupplier`

## How Has This Been Tested?

- Kotest FreeSpec
- `StatusCodeUtilTest`에서 `StatusParameters` 테스트를 겸했습니다.
- 각 섹션에 대한 독립적인 테스트 항목만 포함했습니다.

## Additional Notes

### 자세한 설명은 다음 페이지를 참고하세요:

<table>
<tr>
<td>
<a href="https://nettee.notion.site/2025-type-safe-builder">
  <p><b>See Details (Click): https://nettee.notion.site/2025-type-safe-builder</b></p>
</a>
<figure>
    <a href="https://nettee.notion.site/2025-type-safe-builder">
        <img src="https://github.com/user-attachments/assets/bd21ae23-8c3e-474e-8cf2-e397c200ab7a"
            alt="오픈그래프 이미지. 엔티티 스테이터스 코드 유스케이스."
            width="480"
        />
    <figcaption><p>Entity Status Code 설명<p></figcaption>
    </a>
</figure>
</td>
</tr>
</table>

### Dynamic Generated Test: 많은 경우의 수를 테스트하기 위해 Pair List를 활용했습니다.

General Purpose 기능 목록은 다양한 조합을 모두 테스트하기 위해 동적으로 테스트를 생성했습니다.

```kotlin
val cases = listOf(
    setOf(READ) to 0x40_00_00_00,
    setOf(UPDATE) to 0x20_00_00_00,
    setOf(SUBITEM_READ) to 0x08_00_00_00,
    setOf(SUBITEM_UPDATE) to 0x04_00_00_00,
    setOf(READ, UPDATE) to 0x60_00_00_00,
    setOf(READ, SUBITEM_READ) to 0x48_00_00_00,
    // ...
    setOf(READ, SUBITEM_READ, SUBITEM_UPDATE) to 0x4C_00_00_00,
    setOf(UPDATE, SUBITEM_READ, SUBITEM_UPDATE) to 0x2C_00_00_00,
)

cases.forEach { (features, expectedCode) ->
    "GP: ${features.joinToString()}" {
        val parameters = StatusParameters.generate()
            .generalPurposeFeatures(*features.toTypedArray())
            .systemInfoBits(0)
            .categoryBits(0)
            .instanceBits(0)

        val code = StatusCodeUtil.getAsInt(parameters)

        code shouldBe expectedCode
    }
}
```