### PR TITLE
Core > Time: `MillisecondSupplier` 및 `SystemMilliseconds` 추가

### DIFF
--- a/core/core.settings.gradle.kts
+++ b/core/core.settings.gradle.kts
@@ -6,12 +6,14 @@ val core = rootDir.resolve("core")
 
 
 include(
+    ":time-util",
     ":jpa-core",
     ":exception-handler-core",
     ":cors-api",
     ":cors-webmvc"
 )
 
+project(":time-util").projectDir = core["time-util"]!!
 project(":jpa-core").projectDir = core["jpa-core"]!!
 project(":exception-handler-core").projectDir = core["exception-handler-core"]!!
 project(":cors-webmvc").projectDir = core["nettee-cors-webmvc"]!!

--- a/core/time-util/build.gradle.kts
+++ b/core/time-util/build.gradle.kts
@@ -1,0 +1,16 @@
+// FIXME remove this after root build.gradle.kts supplies below dependencies.
+dependencies {
+    testImplementation("io.kotest:kotest-runner-junit5:5.9.1")
+    testImplementation("io.mockk:mockk:1.13.12")
+    testImplementation(kotlin("script-runtime"))
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.3")
+}
+
+// FIXME remove this after root build.gradle.kts supplies below task.
+kotlin {
+    sourceSets {
+        test {
+            kotlin.srcDirs(listOf("src/test/kotlin"))
+        }
+    }
+}

--- a/core/time-util/src/main/java/nettee/time/MillisecondsSupplier.java
+++ b/core/time-util/src/main/java/nettee/time/MillisecondsSupplier.java
@@ -1,0 +1,6 @@
+package nettee.time;
+
+import java.util.function.LongSupplier;
+
+public interface MillisecondsSupplier extends LongSupplier {
+}

--- a/core/time-util/src/main/java/nettee/time/SystemMilliseconds.java
+++ b/core/time-util/src/main/java/nettee/time/SystemMilliseconds.java
@@ -1,0 +1,8 @@
+package nettee.time;
+
+public final class SystemMilliseconds implements MillisecondsSupplier {
+    @Override
+    public long getAsLong() {
+        return System.currentTimeMillis();
+    }
+}

--- a/core/time-util/src/test/kotlin/nettee/time/SystemMillisecondsTest.kt
+++ b/core/time-util/src/test/kotlin/nettee/time/SystemMillisecondsTest.kt
@@ -1,0 +1,33 @@
+package nettee.time
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.longs.shouldBeLessThanOrEqual
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+
+class SystemMillisecondsTest: FreeSpec({
+    val milliseconds = SystemMilliseconds()
+
+    "getAsLong" - {
+        "Clock-Backward가 발생하지 않는다." {
+            val t0 = System.currentTimeMillis()
+            val result = milliseconds.asLong
+            val t1 = System.currentTimeMillis()
+
+            result shouldBeGreaterThanOrEqual t0
+            result shouldBeLessThanOrEqual t1
+        }
+
+        "concurrent calls should all complete" {
+            coroutineScope {
+                val jobs = (1..10).map {
+                    launch(Dispatchers.Default) { milliseconds.asLong }
+                }
+                jobs.joinAll() // 모두 완료될 때까지 대기
+            }
+        }
+    }
+})


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #62 
<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

**Background**

`Snowflake` 클래스에서 시간에 대해 테스트 가능한 구조로 개선할 수 있도록 추가한 타입입니다.
- 참고: #61 

**추가된 인터페이스 및 클래스**

- `MillisecondSupplier` as a `LongSupplier`
- `SystemMilliseconds` as a `MillisecondSupplier`

## How Has This Been Tested?

- Kotest FreeSpec
- Clock backwards 여부 테스트
- 간단한 Concurrency 테스트
