### PR TITLE
Common: Default Error Code 추가

### DIFF
--- a/common/src/main/java/nettee/common/CustomException.java
+++ b/common/src/main/java/nettee/common/CustomException.java
@@ -78,6 +78,7 @@ public class CustomException extends RuntimeException{
         this(Holder.DEFAULT_ERROR_CODE, payloadSupplier, cause);
     }
 
+    @SuppressWarnings({})
     public ErrorCode getErrorCode() {
         return errorCode;
     }

--- a/common/src/main/java/nettee/common/CustomException.java
+++ b/common/src/main/java/nettee/common/CustomException.java
@@ -53,6 +53,31 @@ public class CustomException extends RuntimeException{
         this.payloadSupplier = payloadSupplier;
     }
 
+    // Default error code constructors
+    public CustomException() {
+        this(Holder.DEFAULT_ERROR_CODE);
+    }
+
+    public CustomException(Throwable cause) {
+        this(Holder.DEFAULT_ERROR_CODE, cause);
+    }
+
+    public CustomException(Runnable runnable) {
+        this(Holder.DEFAULT_ERROR_CODE, runnable);
+    }
+
+    public CustomException(Runnable runnable, Throwable cause) {
+        this(Holder.DEFAULT_ERROR_CODE, runnable, cause);
+    }
+
+    public CustomException(Supplier<Map<String, Object>> payloadSupplier) {
+        this(Holder.DEFAULT_ERROR_CODE, payloadSupplier);
+    }
+
+    public CustomException(Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
+        this(Holder.DEFAULT_ERROR_CODE, payloadSupplier, cause);
+    }
+
     public ErrorCode getErrorCode() {
         return errorCode;
     }

--- a/common/src/main/java/nettee/common/CustomException.java
+++ b/common/src/main/java/nettee/common/CustomException.java
@@ -1,5 +1,7 @@
 package nettee.common;
 
+import org.springframework.http.HttpStatus;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -61,5 +63,54 @@ public class CustomException extends RuntimeException{
 
     public Map<String, Object> getPayload() {
         return payloadSupplier.get();
+    }
+
+    private static final class Holder {
+        private static final ErrorCode DEFAULT_ERROR_CODE = new ErrorCode() {
+            @Override
+            public String name() {
+                return "Server Error";
+            }
+
+            @Override
+            public String message() {
+                return "An error occurred";
+            }
+
+            @Override
+            public HttpStatus httpStatus() {
+                return HttpStatus.INTERNAL_SERVER_ERROR;
+            }
+
+            @Override
+            public CustomException exception() {
+                return new CustomException(this);
+            }
+
+            @Override
+            public CustomException exception(Throwable cause) {
+                return new CustomException(this, cause);
+            }
+
+            @Override
+            public CustomException exception(Runnable runnable) {
+                return new CustomException(this, runnable);
+            }
+
+            @Override
+            public CustomException exception(Runnable runnable, Throwable cause) {
+                return new CustomException(this, runnable, cause);
+            }
+
+            @Override
+            public CustomException exception(Supplier<Map<String, Object>> appendPayload) {
+                return new CustomException(this, appendPayload);
+            }
+
+            @Override
+            public CustomException exception(Supplier<Map<String, Object>> appendPayload, Throwable cause) {
+                return new CustomException(this, appendPayload, cause);
+            }
+        };
     }
 }


### PR DESCRIPTION
# Pull Request

## Issues

- Resolves #66

## Description

- `DEFAULT_ERROR_CODE`를 추가합니다.
  - 내부 클래스를 통해 다음 특징을 얻습니다.
  - Lazy loading supported
  - Thread-safe
- `CustomException`에 `DEFAULT_ERROR_CODE`를 사용하는 생성자 목록을 추가합니다. [(확인)](#additional-notes)

## How Has This Been Tested?

- 의미 있는 테스트 단위를 갖지 않는 것으로 보입니다.

<a id="additional-notes"></a>

## Additional Notes

- **추가된 생성자 목록**  
  생성자 위임: `ErrorCode`를 인자로 받는 생성자로 `DEFAULT_ERROR_CODE`를 전달합니다.  
  ```java
    public CustomException() {
        this(Holder.DEFAULT_ERROR_CODE);
    }

    public CustomException(Throwable cause) {
        this(Holder.DEFAULT_ERROR_CODE, cause);
    }

    public CustomException(Runnable runnable) {
        this(Holder.DEFAULT_ERROR_CODE, runnable);
    }

    public CustomException(Runnable runnable, Throwable cause) {
        this(Holder.DEFAULT_ERROR_CODE, runnable, cause);
    }

    public CustomException(Supplier<Map<String, Object>> payloadSupplier) {
        this(Holder.DEFAULT_ERROR_CODE, payloadSupplier);
    }

    public CustomException(Supplier<Map<String, Object>> payloadSupplier, Throwable cause) {
        this(Holder.DEFAULT_ERROR_CODE, payloadSupplier, cause);
    }
  ```
