### PR TITLE
☀️ Core > Snowflake ID: 밀리초 제공을 '테스트 가능한' 구조로 개선

### DIFF
--- a/core/snowflake/nettee-snowflake-id-api/build.gradle.kts
+++ b/core/snowflake/nettee-snowflake-id-api/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies {
+    api(project(":time-util"))
     compileOnly("org.springframework.boot:spring-boot-autoconfigure:3.4.3")
 }

--- a/core/snowflake/nettee-snowflake-id-api/src/main/java/nettee/snowflake/properties/SnowflakeProperties.java
+++ b/core/snowflake/nettee-snowflake-id-api/src/main/java/nettee/snowflake/properties/SnowflakeProperties.java
@@ -1,8 +1,8 @@
 package nettee.snowflake.properties;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-
-import java.util.Objects;
 
 import static nettee.snowflake.constants.SnowflakeConstants.NETTEE_EPOCH;
 import static nettee.snowflake.constants.SnowflakeConstants.PREFIX;
@@ -13,9 +13,18 @@ public record SnowflakeProperties(
         Long workerId,
         Long epoch
 ) {
+    private static final Logger log = LoggerFactory.getLogger(SnowflakeProperties.class);
+    
     public SnowflakeProperties {
-        Objects.requireNonNull(datacenterId, PREFIX + ".datacenter-id must not be null.");
-        Objects.requireNonNull(workerId, PREFIX + ".worker-id must not be null.");
+        if (datacenterId == null) {
+            datacenterId = 0L;
+            log.warn(PREFIX + ".datacenter-id must not be null.");
+        }
+        
+        if (workerId == null) {
+            workerId = 0L;
+            log.warn(PREFIX + ".worker-id must not be null.");
+        }
         
         if (epoch == null) {
             epoch = NETTEE_EPOCH;

--- a/core/snowflake/nettee-snowflake-id-api/src/test/java/nettee/snowflake/time/TestMilliseconds.java
+++ b/core/snowflake/nettee-snowflake-id-api/src/test/java/nettee/snowflake/time/TestMilliseconds.java
@@ -1,0 +1,25 @@
+package nettee.snowflake.time;
+
+import nettee.time.MillisecondsSupplier;
+
+public final class TestMilliseconds implements MillisecondsSupplier {
+    public long currentMilliseconds;
+    public boolean forceBreak = false;
+    
+    public TestMilliseconds() {
+        currentMilliseconds = System.currentTimeMillis();
+    }
+    
+    @Override
+    public long getAsLong() {
+        if (forceBreak) {
+            throw new RuntimeException("Forced break from timeGen");
+        }
+        
+        return currentMilliseconds;
+    }
+    
+    public void nextMillisecond() {
+        currentMilliseconds += 1L;
+    }
+}

--- a/core/snowflake/nettee-snowflake-id-api/src/test/java/nettee/snowflake/time/TestMilliseconds.java
+++ b/core/snowflake/nettee-snowflake-id-api/src/test/java/nettee/snowflake/time/TestMilliseconds.java
@@ -4,7 +4,6 @@ import nettee.time.MillisecondsSupplier;
 
 public final class TestMilliseconds implements MillisecondsSupplier {
     public long currentMilliseconds;
-    public boolean forceBreak = false;
     
     public TestMilliseconds() {
         currentMilliseconds = System.currentTimeMillis();
@@ -12,10 +11,6 @@ public final class TestMilliseconds implements MillisecondsSupplier {
     
     @Override
     public long getAsLong() {
-        if (forceBreak) {
-            throw new RuntimeException("Forced break from timeGen");
-        }
-        
         return currentMilliseconds;
     }
     

--- a/core/snowflake/nettee-snowflake-id-api/src/test/kotlin/nettee/snowflake/persistence/id/SnowflakeTest.kt
+++ b/core/snowflake/nettee-snowflake-id-api/src/test/kotlin/nettee/snowflake/persistence/id/SnowflakeTest.kt
@@ -1,0 +1,48 @@
+package nettee.snowflake.persistence.id
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import nettee.snowflake.constants.SnowflakeConstants.NETTEE_EPOCH
+import nettee.snowflake.time.TestMilliseconds
+
+class SnowflakeTest : FreeSpec({
+    "[snowflake ID 채번] 특정 밀리세컨드 시간이 주어질 때" - {
+        val testMilliseconds = TestMilliseconds()
+        val testSnowflake = Snowflake(0, 0, NETTEE_EPOCH, testMilliseconds)
+
+        println("현재 밀리세컨드: ${testMilliseconds.currentMilliseconds}")
+
+        "총 4096개의 키 생성" {
+            val ids = (0..4095).map { testSnowflake.nextId() }
+
+            ids.toSet().size shouldBe 4096
+        }
+
+        "이 후 특정 밀리세컨드가 증가하지 않는 상태에서 키 생성 시" - {
+            val thread = Thread {
+                testSnowflake.nextId()
+            }
+
+            thread.start()
+
+            thread.join(500)
+
+            "무한 루프 발생" {
+                // 현재도 쓰레드가 살아 있다면 무한 루프
+                thread.isAlive shouldBe true
+                thread.interrupt()
+            }
+
+            "특정 밀리세컨드에서 증가 할 때 정상 키 생성" {
+                testMilliseconds.nextMillisecond()
+
+                println("다음 밀리세컨드: ${testMilliseconds.currentMilliseconds}")
+                val id = testSnowflake.nextId()
+
+                id shouldNotBe null
+                thread.isAlive shouldBe false
+            }
+        }
+    }
+})

--- a/core/snowflake/nettee-snowflake-id-api/src/test/kotlin/nettee/snowflake/properties/SnowflakePropertiesTest.kt
+++ b/core/snowflake/nettee-snowflake-id-api/src/test/kotlin/nettee/snowflake/properties/SnowflakePropertiesTest.kt
@@ -1,0 +1,23 @@
+package nettee.snowflake.properties
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import nettee.snowflake.constants.SnowflakeConstants.NETTEE_EPOCH
+
+class SnowflakePropertiesTest : FreeSpec({
+    "[초기화] 프로퍼티 입력 값이 null 일 경우" -{
+        val snowflakeProperties = SnowflakeProperties(null, null, null)
+
+        "datacenterId의 값은 0을 반환" {
+            snowflakeProperties.datacenterId shouldBe 0
+        }
+
+        "workerId의 값은 0을 반환" {
+            snowflakeProperties.workerId shouldBe 0
+        }
+
+        "epoch의 값은 NETTEE_EPOCH 반환" {
+            snowflakeProperties.epoch.shouldBe(NETTEE_EPOCH)
+        }
+    }
+})


### PR DESCRIPTION
## Issues

- Resolves #61
- Resolves #83
<!-- 이 PR이 완전히 처리한 이슈의 번호를 작성합니다. PR 병합 시 이슈가 자동으로 close 됩니다. -->
<!-- 다른 레포지터리의 이슈: `Resolves nettee-space/another-repository#0` -->

## Description

- Snowflake 클래스 내부에서 시간을 MillisecondSupplier를 사용해 제공받습니다.
- Snowflake 객체 초기화 시 필요한 속성값(datacenterId, workerId)에 대해 기본값을 적용하도록 개선했습니다.
- 기본값 처리 시, warn 로그를 남깁니다. ( #83 )

<br />

## Review Points

### **🚀  Snowflake ID: 밀리초 제공을 `'테스트 가능한' 구조로 개선의 핵심`은 다음과 같습니다**
- 운영 시에는 현재 시스템의 밀리세컨드를 제공 받아 ID를 채번 합니다.
- 테스트 시에는 사용자가 임의로 밀리세컨드를 조작하여 Snowflake의 동작을 테스트 해야 합니다. 

**위 두 가지를 만족하기 위해, time-util 모듈의 MillisecondSupplier(인터페이스)를 Snowflake 변수에 추가 하였습니다. 👍**

```java
// Snowflake.java
// MillisecondsSupplier  인터페이스 추가
 public Snowflake(long datacenterId, long workerId, long epoch, MillisecondsSupplier millisecondsSupplier) {
        SnowflakeConstructingValidator.validateDatacenterId(datacenterId);
        SnowflakeConstructingValidator.validateWorkerId(workerId);
        
        this.workerId = workerId;
        this.datacenterId = datacenterId;
        this.epoch = epoch >= 0 ? epoch : NETTEE_EPOCH;
        this.millisecondsSupplier = millisecondsSupplier;
}
```
### 기대되는 퍼포먼스는 다음과 같습니다. 

실제 프로덕션 코드는 현재 시스템의 밀리세컨드를 제공 받기 위해 MillisecondsSupplier의 구현체 클래스 SystemMilliseconds 클래스를 넣어 줍니다. 

``` java
// Snowflake.java
public Snowflake(SnowflakeProperties properties) {
     this(properties.datacenterId(), properties.workerId(), properties.epoch(), new SystemMilliseconds());
}
```

테스트 코드에서는 임의로 밀리세컨드를 조작하기 위한  MillisecondsSupplier의 구현체 클래스 TestMilliseconds 클래스를 넣어 줍니다.

``` java
// SnowflakeTest.kt
    "[snowflake ID 채번] 특정 밀리세컨드 시간이 주어질 때" - {
        val testMilliseconds = TestMilliseconds()
        val testSnowflake = Snowflake(0, 0, NETTEE_EPOCH, testMilliseconds)
...
}
```
MillisecondsSupplier의 구현체 클래스 TestMilliseconds 클래스는 코드로 간단하게 봐주시면 감사합니다.

### 결국 인터페이스를 응용하여, 운영과 테스트를 별개로 작동 시킬 수 있는 구조를 가지게 됐습니다.

<br />

## How Has This Been Tested?

- 테스트 환경: Kotlin + Kotest 기반

- TestMilliseconds를 활용한 단위 테스트 작성 완료 (SnowflakeTest)
   1. 특정 밀리초에 4096개 시퀀스 생성 테스트
   2. 밀리초 증가 없는 경우 4097번째 키 생성 시, 무한 루프 진입 검증
   3. 시간 증가 후 ID 생성 정상 완료 확인

![image](https://github.com/user-attachments/assets/02f014db-9b85-4c8c-b3cb-27fe1a0acbf6)


<!-- 테스트를 생략하거나 육안으로 실행만 확인했다고 쓸 수도 있습니다. -->

<br />

## Additional Notes

- SnowflakeTest 시 tilNextMillis()에 Thread.interrupted() 체크 추가 여부를 추가하였습니다. 이는 무한 루프가 돌면 thread를 중지시키기 위함이며, test 환경에서만 적응 되도록 `assert`를 이용하였습니다.
